### PR TITLE
chore(heroku) Remove the Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node app.js


### PR DESCRIPTION
- remove Procfile so that Heroku can build command with default scripts